### PR TITLE
modernize things (for 2.12.16/2.13.9 friendliness)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,8 @@ sudo: false
 language: scala
 
 scala:
-- 2.10.7
-- 2.11.12
-- 2.12.8
-- 2.13.0
+- 2.12.15
+- 2.13.8
 
 jdk:
 - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,3 @@ cache:
   directories:
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot
-    - $HOME/.sbt/launchers/0.13.13

--- a/README.md
+++ b/README.md
@@ -173,17 +173,6 @@ To use this plugin in your project, add the following line to your `build.sbt` f
 addCompilerPlugin("com.github.tomasmikula" % "pascal" % "0.4.0" cross CrossVersion.full)
 ```
 
-If your project uses Scala 2.10, also add
-
-```scala
-libraryDependencies ++= (scalaBinaryVersion.value match {
-  case "2.10" =>
-    compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full) :: Nil
-  case _ =>
-    Nil
-})
-```
-
 ## Relation to `kind-projector`
 
 `kind-projector`'s [polymorphic lambdas](https://github.com/non/kind-projector#polymorphic-lambda-values)

--- a/build.sbt
+++ b/build.sbt
@@ -11,12 +11,12 @@ crossTarget := {
   target.value / s"scala-${scalaVersion.value}"
 }
 
-unmanagedSourceDirectories in Compile += {
+Compile / unmanagedSourceDirectories += {
   CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2L, v)) if v >= 13 =>
-      (baseDirectory in Compile).value / s"src/main/scala-2.13+"
+      (Compile / baseDirectory).value / s"src/main/scala-2.13+"
     case _ =>
-      (baseDirectory in Compile).value / s"src/main/scala-2.13-"
+      (Compile / baseDirectory).value / s"src/main/scala-2.13-"
   }
 }
 
@@ -50,21 +50,21 @@ List(Compile, Test) flatMap { config =>
   Seq(
     // Notice this is :=, not += - all the warning/lint options are simply
     // impediments in the repl.
-    scalacOptions in console in config := Seq(
+    config / console / scalacOptions := Seq(
       "-language:_",
-      "-Xplugin:" + (packageBin in Compile).value
+      "-Xplugin:" + (Compile / packageBin).value
     )
   )
 }
 
-scalacOptions in Test ++= {
-  val jar = (packageBin in Compile).value
+Test / scalacOptions ++= {
+  val jar = (Compile / packageBin).value
   Seq(s"-Xplugin:${jar.getAbsolutePath}", s"-Jdummy=${jar.lastModified}") // ensures recompile
 }
 
-scalacOptions in Test += "-Yrangepos"
+Test / scalacOptions += "-Yrangepos"
 
-fork in Test := true
+Test / fork := true
 
 
 /******************
@@ -75,7 +75,7 @@ import ReleaseTransformations._
 
 releaseCrossBuild := true
 releasePublishArtifactsAction := PgpKeys.publishSigned.value
-publishArtifact in Test := false
+Test / publishArtifact := false
 publishMavenStyle := true
 pomIncludeRepository := Function.const(false)
 

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ Compile / unmanagedSourceDirectories += {
   }
 }
 
-addCompilerPlugin("org.typelevel" % "kind-projector" % "0.11.0" cross CrossVersion.full)
+addCompilerPlugin("org.typelevel" % "kind-projector" % "0.13.2" cross CrossVersion.full)
 
 libraryDependencies ++= Seq(
   scalaOrganization.value % "scala-compiler" % scalaVersion.value,

--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,8 @@ organization := "com.github.tomasmikula"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 homepage := Some(url("http://github.com/TomasMikula/pascal"))
 
-scalaVersion := "2.12.8"
-crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.8", "2.12.9", "2.12.10", "2.13.0", "2.13.1", "2.13.2")
+scalaVersion := crossScalaVersions.value.head
+crossScalaVersions := Seq("2.12.15", "2.13.8")
 crossVersion := CrossVersion.full
 crossTarget := {
   // workarond for https://github.com/sbt/sbt/issues/5097
@@ -25,16 +25,6 @@ addCompilerPlugin("org.typelevel" % "kind-projector" % "0.11.0" cross CrossVersi
 libraryDependencies ++= Seq(
   scalaOrganization.value % "scala-compiler" % scalaVersion.value,
   "org.scalatest" %% "scalatest" % "3.0.8" % Test
-)
-
-libraryDependencies ++= (scalaBinaryVersion.value match {
-  case "2.10" => scala210ExtraDeps
-  case _      => Nil
-})
-
-def scala210ExtraDeps = Seq(
-  compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
-  "org.scalamacros" %% "quasiquotes" % "2.1.0"
 )
 
 scalacOptions ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.10
+sbt.version=1.6.2

--- a/src/test/scala/pascal/polyval.scala
+++ b/src/test/scala/pascal/polyval.scala
@@ -42,7 +42,7 @@ class PolyVals extends FunSuite {
 
   // Const functor and constructors
   final class Const[A, B](val getConst: A)
-  type ConstA[A] = Forall[Const[A, ?]]
+  type ConstA[A] = Forall[Const[A, *]]
   type ConstMaker1 = Forall[λ[α => α => ConstA[α]]]
   type ConstMaker2 = Forall2[λ[(α, β) => α => Const[α, β]]]
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.1-SNAPSHOT"
+ThisBuild / version := "0.4.1-SNAPSHOT"


### PR DESCRIPTION
this came up in the Scala 2 community build -- both Scala 2.12.16 and Scala 2.13.9 will disallow the use of `?` with kind-projector (requiring `*` instead), and then the rest of this PR is just gravy

you don't have to merge it if you don't want — the community build will be fine regardless (we can use a fork)